### PR TITLE
Fix: Standardize capitalization in RIP-7755 documentation

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -33,7 +33,7 @@ make coverage
 The contracts making up RIP-7755 can be split up into source chain contracts and destination chain contracts.
 
 - **Source Chain**
-  - [`RIP7755Outbox`](./src/RIP7755Outbox.sol) - the entrypoint for a user submitting a request for a cross-chain call
+  - [`RIP7755Outbox`](./src/RIP7755Outbox.sol) - The entrypoint for a user submitting a request for a cross-chain call
   - Provers
     - [`ArbitrumProver`](./src/provers/ArbitrumProver.sol) - Implements a proof system to validate state on Arbitrum. Should be used if sending a call to an Arbitrum chain
     - [`OPStackProver`](./src/provers/OPStackProver.sol) - Implements a proof system to validate state on any OP Stack chain. Should be used if sending a call to an OP Stack chain


### PR DESCRIPTION
This commit updates the RIP-7755 documentation to ensure consistent capitalization. The descriptions for RIP7755Outbox and related contracts now start with a capital letter, matching the style of RIP7755Inbox. These adjustments improve the readability and clarity of the documentation without changing any content.