### PR TITLE
syntax correction RIP7755Inbox.sol

### DIFF
--- a/contracts/src/RIP7755Inbox.sol
+++ b/contracts/src/RIP7755Inbox.sol
@@ -18,7 +18,7 @@ contract RIP7755Inbox {
 
     struct MainStorage {
         /// @notice A mapping from the keccak256 hash of a `CrossChainRequest` to its `FulfillmentInfo`. This can only be set once per call
-        mapping(bytes32 requestHash => FulfillmentInfo) fulfillmentInfo;
+        mapping(bytes32 => FulfillmentInfo) fulfillmentInfo;
     }
 
     /// @notice Stored on verifyingContract and proved against in originationContract


### PR DESCRIPTION
There is a typo in the mapping declaration, 

It seems that in Solidity, mappings are used in a way that correction has been provided,

It'll be more syntactically correct.