### PR TITLE
little fix OPStackProver.sol

### DIFF
--- a/contracts/src/provers/OPStackProver.sol
+++ b/contracts/src/provers/OPStackProver.sol
@@ -144,7 +144,7 @@ contract OPStackProver is IProver {
     function _extractL2StateRootAndTimestamp(bytes memory encodedBlockArray) private pure returns (bytes32, uint256) {
         RLPReader.RLPItem[] memory blockFields = encodedBlockArray.readList();
 
-        if (blockFields.length < 15) {
+        if (blockFields.length < 16) {
             revert InvalidBlockFieldRLP();
         }
 


### PR DESCRIPTION
The error says the block should have 16 fields, but the condition checks for 15, which might be a typo. Fixing the condition matches it with the error.