### PR TITLE
Typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A successful storage proof from the source chain should follow these steps:
 5. Use the destination chain's state root to prove an account’s storage root. In this context, the “account” is the `RIP7755Inbox` contract on the destination chain.
 6. Prove the storage slot in `RIP7755Inbox` that represents a receipt of the requested call having been made.
 
-We use Storage Proofs in this manner to validate state for early iterations of a proof-of-concept for the protocol. However, this is not the only method available. To maintain flexibility for future, potentially more efficient or easier-to-implement solutions, we have abstracted the proof system from the `RIP7755Inbox` and `RIP7755Outbox` contracts.
+We use Storage Proofs in this manner to validate state for early iterations of a proof-of-concept for the protocol. However, this is not the only method available. To maintain flexibility for the future, potentially more efficient or easier-to-implement solutions, we have abstracted the proof system from the `RIP7755Inbox` and `RIP7755Outbox` contracts.
 
 ## License
 


### PR DESCRIPTION
#### Description  
This pull request addresses a minor but important grammatical error in the RIP-7755 documentation. Specifically, in the following sentence:  

> "To maintain flexibility for future, potentially more efficient or easier-to-implement solutions, we have abstracted the proof system from the `RIP7755Inbox` and `RIP7755Outbox` contracts."  

The word **future** was missing the definite article "the," which is necessary for proper grammatical construction in this context.  

The corrected version reads:  
> "To maintain flexibility for the future, potentially more efficient or easier-to-implement solutions, we have abstracted the proof system from the `RIP7755Inbox` and `RIP7755Outbox` contracts."  

#### Importance of the Fix  
1. **Clarity**: Ensuring correct grammar improves the readability and professionalism of the documentation, making it easier for developers and stakeholders to understand.  
2. **Consistency**: Correct grammar helps maintain the high standards of the RIP documentation, ensuring it reflects well on the project's attention to detail.  
3. **Perception**: Even small errors in official documentation can lead to a perception of carelessness, which this fix addresses.  

#### Scope of Changes  
- Updated the sentence in the documentation to include the article "the" before "future."  

No other changes have been made to the document.  

#### Testing  
As this is a documentation-only change, no testing is required.  
