### PR TITLE
docs: Fix typo in Docker-Compose file name Update README.md

### DIFF
--- a/services/ts-filler/README.md
+++ b/services/ts-filler/README.md
@@ -59,7 +59,7 @@ bun run index.ts
 
 ## Docker Support
 
-The `ts-filler` service can also be run inside a Docker container. The provided `docker-compose.tml` file sets up the environment and installs the necessary dependencies.
+The `ts-filler` service can also be run inside a Docker container. The provided `docker-compose.yml` file sets up the environment and installs the necessary dependencies.
 
 To build and run the Docker container, use the following command:
 


### PR DESCRIPTION
In the Docker-Compose configuration, the file is named "tml" instead of the correct "docker-compose.yml".
This typo could cause problems when running or referencing the Docker setup. 

I've corrected the file name to ensure it matches the expected format and resolves any potential issues with Docker execution.

Based.