### PR TITLE
Typo Fix in `HashiProver.sol`

### DIFF
--- a/contracts/src/libraries/provers/HashiProver.sol
+++ b/contracts/src/libraries/provers/HashiProver.sol
@@ -34,7 +34,7 @@ library HashiProver {
         StateValidator.AccountProofParameters dstAccountProofParams;
     }
 
-    /// @notice This error is thrown when verification of proof.blockHash agaist the one stored in Hashi fails
+    /// @notice This error is thrown when verification of proof.blockHash against the one stored in Hashi fails
     error InvalidBlockHeader();
 
     /// @notice This error is thrown when verification of the authenticity of the `RIP7755Inbox` storage on the


### PR DESCRIPTION
## Typo Fix in `HashiProver.sol`

This pull request fixes a typographical error in the `HashiProver.sol` file. The word "agaist" has been corrected to "against."

### Changes:
- Corrected the typo from "agaist" to "against" in the comment related to block hash verification.

### Checklist:
- [x] Corrected the typographical error.
- [x] Changes reviewed and tested.
